### PR TITLE
Fix WatchScreen carré

### DIFF
--- a/android/app/src/main/kotlin/com/alcatel/ptt_companion/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/alcatel/ptt_companion/MainActivity.kt
@@ -1,6 +1,13 @@
 package com.alcatel.ptt_companion
 
 import io.flutter.embedding.android.FlutterActivity
+import android.os.Bundle
 
 class MainActivity: FlutterActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        intent.putExtra("background_mode", "transparent")
+        super.onCreate(savedInstanceState)
+    }
+
 }


### PR DESCRIPTION
Close #1 

Modifications :

- MainActivity (rendu de l'activité avec un background transparent)


Fix : 

- L'écran est donc rond car il n'y a pas de fond.